### PR TITLE
update nodejs:6 runtime to 6.11.4

### DIFF
--- a/core/nodejs6Action/CHANGELOG.md
+++ b/core/nodejs6Action/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 
 
+## 1.1.0
+Change: Update NodeJS version
+
+Node version = 6.11.4
 ## 1.0.0
 Change: Initial release
 

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -1,7 +1,7 @@
 FROM nodejsactionbase
 
 # based on https://github.com/nodejs/docker-node
-ENV NODE_VERSION 6.9.1
+ENV NODE_VERSION 6.11.4
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"


### PR DESCRIPTION
This will allow to push a new image to dockerhub with nodejs 6.11.4