### PR TITLE
update openwhisk npm package for nodejs6 and nodejs8

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -422,7 +422,7 @@ Apache CouchDB Nano 6.2.0 (nano - https://github.com/apache/couchdb-nano/)
   License included at licenses/LICENSE-nano.txt, or https://github.com/apache/couchdb-nano/blob/master/LICENSE
   Copyright (c) 2016 IBM Cloudant, Inc. All rights reserved.
 
-OpenWhisk Client for JavaScript 3.14.0 (openwhisk - https://github.com/apache/incubator-openwhisk-client-js/)
+OpenWhisk Client for JavaScript 3.15.0 (openwhisk - https://github.com/apache/incubator-openwhisk-client-js/)
   License included at licenses/LICENSE-openwhisk.txt, or https://github.com/apache/incubator-openwhisk-client-js/blob/master/LICENSE.txt
   Copyright 2015-2016  IBM Corporation
 

--- a/core/nodejs6Action/CHANGELOG.md
+++ b/core/nodejs6Action/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 # NodeJS 6 OpenWhisk Runtime Container
 
+## 1.9.0
+Change: Update npm openwhisk package from `3.14.0` to `3.15.0`
+
+- [openwhisk v3.15.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+
 ## 1.8.1
 Change: Update Node.js
 

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -62,7 +62,7 @@ nano@6.2.0 \
 node-uuid@1.4.7 \
 nodemailer@2.6.4 \
 oauth2-server@2.4.1 \
-openwhisk@3.14.0 \
+openwhisk@3.15.0 \
 pkgcloud@1.4.0 \
 process@0.11.9 \
 pug@">=2.0.0-beta6 <2.0.1" \

--- a/core/nodejs8Action/CHANGELOG.md
+++ b/core/nodejs8Action/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 # NodeJS 8 OpenWhisk Runtime Container
 
+## 1.6.0
+Change: Update openwhisk npm package from `3.14.0` to `3.15.0`
+
+- [openwhisk v3.15.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
+
 ## 1.5.1
 Change: Update Node.js
 

--- a/core/nodejs8Action/package.json
+++ b/core/nodejs8Action/package.json
@@ -8,7 +8,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "openwhisk": "3.14.0",
+    "openwhisk": "3.15.0",
     "body-parser": "1.18.2",
     "express": "4.16.2"
   }


### PR DESCRIPTION
A new version of the openwhisk NPM package was released and both of the NodeJS runtimes, version 6 and 8, had to be updated to pick up that change.  

Issue tracking here: https://github.com/apache/incubator-openwhisk/issues/3597