### PR TITLE
add to travis.yml the runtime repo to the deploy block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,12 @@ deploy:
     on:
       tags: true
       all_branches: true
+      repo: apache/openwhisk-incubator-runtime-nodejs
   - provider: script
     script: "./tools/travis/publish.sh openwhisk 6 master && ./tools/travis/publish.sh openwhisk 8 master"
     on:
       branch: master
+      repo: apache/openwhisk-incubator-runtime-nodejs
 
 env:
   global:


### PR DESCRIPTION
This PR is to lock down the Deploy step of the Travis.yml so that it only executes when the repo matches the "upstream" repo, 'incubator-openwhisk-runtime-nodejs'