### PR TITLE
fix issue with travis repo misspelling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,12 @@ deploy:
     on:
       tags: true
       all_branches: true
-      repo: apache/openwhisk-incubator-runtime-nodejs
+      repo: apache/incubator-openwhisk-runtime-nodejs
   - provider: script
     script: "./tools/travis/publish.sh openwhisk 6 master && ./tools/travis/publish.sh openwhisk 8 master"
     on:
       branch: master
-      repo: apache/openwhisk-incubator-runtime-nodejs
+      repo: apache/incubator-openwhisk-runtime-nodejs
 
 env:
   global:


### PR DESCRIPTION
There was a typo in the repo name in the .travis.yml , the repo 'incubator-openwhisk-runtime-nodejs' was incorrectly entered as 'openwhisk-incubator-runtime-nodejs'