### PR TITLE
Build wskadmin-next.

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -48,6 +48,7 @@ TERM=dumb ./gradlew \
 :common:scala:install \
 :core:controller:install \
 :core:invoker:install \
+:tools:admin:install \
 :tests:install
 
 # Build runtime


### PR DESCRIPTION
@chetanmeh I think this shouldn't be necessary and indicates an overly inclusive compilation step in this repo but the patch should resolve the Travis failure on master.

```
* What went wrong:
Could not resolve all files for configuration ':tests:testCompileClasspath'.
> Could not find org.apache.openwhisk:openwhisk-admin-tools:1.0.0-SNAPSHOT.
  Searched in the following locations:
      https://repo.maven.apache.org/maven2/org/apache/openwhisk/openwhisk-admin-tools/1.0.0-SNAPSHOT/maven-metadata.xml
      https://repo.maven.apache.org/maven2/org/apache/openwhisk/openwhisk-admin-tools/1.0.0-SNAPSHOT/openwhisk-admin-tools-1.0.0-SNAPSHOT.pom
      https://repo.maven.apache.org/maven2/org/apache/openwhisk/openwhisk-admin-tools/1.0.0-SNAPSHOT/openwhisk-admin-tools-1.0.0-SNAPSHOT.jar
      file:/home/travis/.m2/repository/org/apache/openwhisk/openwhisk-admin-tools/1.0.0-SNAPSHOT/maven-metadata.xml
      file:/home/travis/.m2/repository/org/apache/openwhisk/openwhisk-admin-tools/1.0.0-SNAPSHOT/openwhisk-admin-tools-1.0.0-SNAPSHOT.pom
      file:/home/travis/.m2/repository/org/apache/openwhisk/openwhisk-admin-tools/1.0.0-SNAPSHOT/openwhisk-admin-tools-1.0.0-SNAPSHOT.jar
  Required by:
      project :tests > org.apache.openwhisk:openwhisk-tests:1.0.0-SNAPSHOT
```