### PR TITLE
Change base image to alpine linux

### DIFF
--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -19,10 +19,29 @@ FROM nodejsactionbase
 
 # based on https://github.com/nodejs/docker-node
 ENV NODE_VERSION 6.14.4
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
 
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+        binutils-gold \
+        curl \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz"
 
 # workaround for this: https://github.com/npm/npm/issues/9863
 RUN cd $(npm root -g)/npm \

--- a/core/nodejs8Action/Dockerfile
+++ b/core/nodejs8Action/Dockerfile
@@ -15,11 +15,34 @@
 # limitations under the License.
 #
 
-FROM node:8.11.4
-RUN apt-get update && apt-get install -y \
-    imagemagick \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+FROM alpine:3.4
+
+ENV NODE_VERSION 8.11.4
+
+RUN apk update && apk add imagemagick && apk --update add tar && apk add xz \
+    && addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+        binutils-gold \
+        curl \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) \
+    && make install \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz"
+
 WORKDIR /nodejsAction
 COPY . .
 # COPY the package.json to root container, so we can install npm packages a level up from user's packages, so user's packages take precedence

--- a/core/nodejsActionBase/Dockerfile
+++ b/core/nodejsActionBase/Dockerfile
@@ -15,12 +15,10 @@
 # limitations under the License.
 #
 
-FROM buildpack-deps:trusty-curl
-
-ENV DEBIAN_FRONTEND noninteractive
+FROM alpine:3.4
 
 # Initial update and some basics.
-RUN apt-get update && apt-get install -y imagemagick && apt-get install -y unzip
+RUN apk update && apk add imagemagick && apk --update add tar && apk add xz
 
 ADD . /nodejsAction
 # COPY the package.json to root container, so we can install npm packages a level up from user's packages, so user's packages take precedence


### PR DESCRIPTION
Alpine Linux is a Linux distribution based on musl and BusyBox, primarily
designed for "power users who appreciate security, simplicity and resource
efficiency", so it is necessary to change base image to alpine linux.