### PR TITLE
Fixes #63 - Support errors thrown from async functions

### DIFF
--- a/core/nodejsActionBase/runner.js
+++ b/core/nodejsActionBase/runner.js
@@ -114,7 +114,11 @@ function NodeActionRunner() {
                     if (!error) {
                         resolve({ error: {}});
                     } else {
-                        resolve({ error: error });
+                        // Log stack trace for rejected promises.
+                        if (error.message) {
+                            console.error(error)
+                        }
+                        resolve({ error: error.toString() });
                     }
                 });
             }


### PR DESCRIPTION
Return error string from errors and log stack trace for rejected promises.