### PR TITLE
use stretch instead of jessie for nodejs10

### DIFF
--- a/core/nodejs10Action/Dockerfile
+++ b/core/nodejs10Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:10.13.0
+FROM node:10.13.0-stretch
 RUN apt-get update && apt-get install -y \
     imagemagick \
     unzip \


### PR DESCRIPTION
Since `nodejs:8` is based on jessie, is best to have the new runtime `nodejs:10` depend on `stretch`
