### PR TITLE
bump nodejs versions 10.15.0, 8.15.0, 6.16.0

### DIFF
--- a/core/nodejs10Action/Dockerfile
+++ b/core/nodejs10Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:10.14.2-stretch
+FROM node:10.15.0-stretch
 RUN apt-get update && apt-get install -y \
     imagemagick \
     unzip \

--- a/core/nodejs6Action/CHANGELOG.md
+++ b/core/nodejs6Action/CHANGELOG.md
@@ -26,7 +26,7 @@ Changes:
 
 - [openwhisk v3.18.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 
-Node.js version = [6.15.1](https://nodejs.org/en/blog/release/v6.15.1/)
+Node.js version = [6.16.0](https://nodejs.org/en/blog/release/v6.16.0/)
 
 ## 1.12.0
 Change: Update npm openwhisk package from `3.16.0` to `3.17.0`

--- a/core/nodejs6Action/Dockerfile
+++ b/core/nodejs6Action/Dockerfile
@@ -18,7 +18,7 @@
 FROM nodejsactionbase
 
 # based on https://github.com/nodejs/docker-node
-ENV NODE_VERSION 6.15.1
+ENV NODE_VERSION 6.16.0
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"

--- a/core/nodejs8Action/CHANGELOG.md
+++ b/core/nodejs8Action/CHANGELOG.md
@@ -26,7 +26,7 @@ Changes:
 
 - [openwhisk v3.18.0](https://www.npmjs.com/package/openwhisk) - JavaScript client library for the OpenWhisk platform. Provides a wrapper around the OpenWhisk APIs.
 
-Node.js version = [8.14.0](https://nodejs.org/en/blog/release/v8.14.0/)
+Node.js version = [8.15.0](https://nodejs.org/en/blog/release/v8.15.0/)
 
 ## 1.9.0 (Apache 1.12)
 Change: Update openwhisk npm package from `3.16.0` to `3.17.0`

--- a/core/nodejs8Action/Dockerfile
+++ b/core/nodejs8Action/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM node:8.14.0
+FROM node:8.15.0
 RUN apt-get update && apt-get install -y \
     imagemagick \
     unzip \


### PR DESCRIPTION
bump nodejs versions 10.15.0, 8.15.0, 6.16.0
https://nodejs.org/en/blog/release/v10.15.0/
https://nodejs.org/en/blog/release/v8.15.0/
https://nodejs.org/en/blog/release/v6.16.0/
