### PR TITLE
Add use() method to short-circuit requests with no route handlers

### DIFF
--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -38,10 +38,17 @@ app.use(bodyParser.json({ limit: "48mb" }));
 app.post('/init', wrapEndpoint(service.initCode));
 app.post('/run',  wrapEndpoint(service.runCode));
 
-app.use(function(req, res, next) {
-    console.error(err.stack);
-    res.status(500).json({ error: "Bad request." });
-  });
+// short-circuit any requests to invalid routes (endpoints) that we have no handlers for.
+app.use(function (req, res, next) {
+    res.status(500).json({error: "Bad request."});
+});
+
+// register a default error handler. This effectively only gets called when invalid JSON is received (JSON Parser)
+// and we do not wish the default handler to send back HTML in the body of the response.
+app.use(function (err, req, res, next) {
+    console.log(err.stackTrace);
+    res.status(500).json({error: "Bad request."});
+});
 
 service.start(app);
 

--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -44,7 +44,7 @@ app.use(function (req, res, next) {
 });
 
 // register a default error handler. This effectively only gets called when invalid JSON is received (JSON Parser)
-// and we do not wish the default handler to send back HTML in the body of the response.
+// and we do not wish the default handler to error with a 400 and send back HTML in the body of the response.
 app.use(function (err, req, res, next) {
     console.log(err.stackTrace);
     res.status(500).json({error: "Bad request."});

--- a/core/nodejsActionBase/app.js
+++ b/core/nodejsActionBase/app.js
@@ -38,7 +38,7 @@ app.use(bodyParser.json({ limit: "48mb" }));
 app.post('/init', wrapEndpoint(service.initCode));
 app.post('/run',  wrapEndpoint(service.runCode));
 
-app.use(function(err, req, res, next) {
+app.use(function(req, res, next) {
     console.error(err.stack);
     res.status(500).json({ error: "Bad request." });
   });
@@ -47,7 +47,7 @@ service.start(app);
 
 /**
  * Wraps an endpoint written to return a Promise into an express endpoint,
- * producing the appropriate HTTP response and closing it for all controlable
+ * producing the appropriate HTTP response and closing it for all controllable
  * failure modes.
  *
  * The expected signature for the promise value (both completed and failed)

--- a/core/nodejsActionBase/src/service.js
+++ b/core/nodejsActionBase/src/service.js
@@ -58,7 +58,6 @@ function NodeActionService(config) {
      * @param app express app
      */
     this.start = function start(app) {
-        var self = this;
         server = app.listen(app.get('port'), function() {
             var host = server.address().address;
             var port = server.address().port;


### PR DESCRIPTION
It appears that the code was attempting to use the Node Express "use()" middleware to intercept and return a 500 error if the runtime was hit by any requests not ```/init``` or ```/run``` as follows:
```
app.use(function (err, req, res, next) {  // <== use without “err” parm.
    console.error(err.stack); // <== REMOVE since "err" would no longer be a valid parm.
    res.status(500).json({error: "Bad request."});
});
```

however, the method only has 3 valid parms. so it appears Node Express ignored the middle filter registration completely and the code was never invoked since it had too many parms. That is, the "err" parm. (as the first parm.) was "extra" and the signature had too many args.

This PR removes the "err" parm., as well as the now invalid console.error() call.

Please note (in addition) I fixed a typo, as well as removed an used variable (i.e., "var self") which is never used.